### PR TITLE
feat: add page endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ Custom GPT ──► (OpenAPI Action) ──► n8n Web‑hook ──► Functi
 
 | Path          | Verb     | Purpose                                                                                     |
 | ------------- | -------- | ------------------------------------------------------------------------------------------- |
-| `/getDB`      | **GET**  | Fetch database meta by `database_id` query param                                            |
+| `/createPage` | **POST** | Create a page inside a database. Payload shape identical to Notion’s but wrapped in `body` |
+| `/getDB`      | **GET**  | Fetch database meta by `database_id` query param |
+| `/getPage`    | **GET**  | Retrieve a page by `page_id` query param |
 | `/queryDB`    | **POST** | Complex database query.  **All user params MUST be nested under a top‑level `body` object** |
-| `/createPage` | **POST** | Create a page inside a database. Payload shape identical to Notion’s but wrapped in `body`  |
+| `/updatePage` | **POST** | Update page properties. Payload must be wrapped in `body` |
 
 > **IMPORTANT RULES**
 >

--- a/openapi3-spec-webhook
+++ b/openapi3-spec-webhook
@@ -207,6 +207,110 @@
           }
         }
       }
+    },
+    "/getPage": {
+      "get": {
+        "summary": "Retrieve a Notion-style page by ID",
+        "operationId": "getPage",
+        "x-openai-isConsequential": false,
+        "x-openai-requiresUserConfirmation": false,
+        "parameters": [
+          {
+            "name": "page_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Page details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "description": "Page properties"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid page_id or structure"
+          }
+        }
+      }
+    },
+    "/updatePage": {
+      "post": {
+        "summary": "Update a Notion-style page (nested under 'body')",
+        "operationId": "updatePage",
+        "x-openai-isConsequential": false,
+        "x-openai-requiresUserConfirmation": false,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["page_id", "body"],
+                "properties": {
+                  "page_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "body": {
+                    "type": "object",
+                    "properties": {
+                      "properties": {
+                        "type": "object",
+                        "description": "Properties to update"
+                      },
+                      "archived": {
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated page details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "page_id": {
+                      "type": "string"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "description": "Updated page properties"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or structure"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add `/getPage` endpoint to fetch page details
- add `/updatePage` endpoint to modify page properties
- document new endpoints in the README

## Testing
- `npm run lint:spec` *(fails: Could not read package.json)*
- `npm run lint:md` *(fails: Could not read package.json)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683ff2a4fd10832fb9e0f2262be04656