### PR TITLE
Move OpenAPI spec into dedicated folder

### DIFF
--- a/openapi/notion-webhook.json
+++ b/openapi/notion-webhook.json
@@ -125,8 +125,10 @@
                       }
                     },
                     "next_cursor": {
-                      "type": "string",
-                      "nullable": true
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "has_more": {
                       "type": "boolean"


### PR DESCRIPTION
## Summary
- move spec to `openapi/notion-webhook.json`
- adjust spec to satisfy OpenAPI linter
- remove old `openapi3-spec-webhook`

## Testing
- `openapi lint openapi/notion-webhook.json`
- `markdownlint README.md` *(fails: line length, fenced code issues)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68406c4977ac832fb4684ada5b19ce6d