### PR TITLE
Alphabetize OpenAPI spec

### DIFF
--- a/openapi/notion-webhook.json
+++ b/openapi/notion-webhook.json
@@ -1,212 +1,208 @@
 {
-  "openapi": "3.1.0",
   "info": {
-    "title": "Notion Custom API (Body Nested)",
     "description": "Modified to support n8n Webhook parsing. All parameters are wrapped in a 'body' object.",
+    "title": "Notion Custom API (Body Nested)",
     "version": "1.0.2"
   },
-  "servers": [
-    {
-      "url": "https://qylabn8n.duckdns.org/webhook",
-      "description": "Main API server"
-    }
-  ],
+  "openapi": "3.1.0",
   "paths": {
-    "/getDB": {
-      "get": {
-        "summary": "Retrieve a Notion-style database by ID",
-        "operationId": "getDB",
-        "x-openai-isConsequential": false,
-        "x-openai-requiresUserConfirmation": false,
-        "parameters": [
-          {
-            "name": "database_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Database details",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "properties": {
-                      "type": "object",
-                      "description": "Database property schema"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid database_id or structure"
-          }
-        }
-      }
-    },
-    "/queryDB": {
-      "post": {
-        "summary": "Query a Notion-style database (nested under 'body')",
-        "operationId": "queryDB",
-        "x-openai-isConsequential": false,
-        "x-openai-requiresUserConfirmation": false,
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": ["database_id", "body"],
-                "properties": {
-                  "database_id": {
-                    "type": "string",
-                    "format": "uuid"
-                  },
-                  "body": {
-                    "type": "object",
-                    "properties": {
-                      "filter": {
-                        "type": "object",
-                        "description": "Compound filter using and/or logic"
-                      },
-                      "sorts": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "property": {
-                              "type": "string"
-                            },
-                            "direction": {
-                              "type": "string",
-                              "enum": ["ascending", "descending"]
-                            }
-                          }
-                        }
-                      },
-                      "page_size": {
-                        "type": "integer",
-                        "default": 100,
-                        "maximum": 100
-                      },
-                      "start_cursor": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Query results",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "results": {
-                      "type": "array",
-                      "items": {
-                        "type": "object"
-                      }
-                    },
-                    "next_cursor": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request or structure"
-          }
-        }
-      }
-    },
     "/createPage": {
       "post": {
-        "summary": "Create a Notion-style page in a database (nested under 'body')",
         "operationId": "createPage",
-        "x-openai-isConsequential": false,
-        "x-openai-requiresUserConfirmation": false,
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": ["database_id", "body"],
                 "properties": {
-                  "database_id": {
-                    "type": "string",
-                    "format": "uuid"
-                  },
                   "body": {
-                    "type": "object",
-                    "required": ["properties"],
                     "properties": {
-                      "properties": {
-                        "type": "object",
-                        "description": "Mapping of database property names to values for the new page"
-                      },
                       "children": {
-                        "type": "array",
                         "description": "Optional array of block children to include under the page",
                         "items": {
                           "type": "object"
-                        }
+                        },
+                        "type": "array"
+                      },
+                      "properties": {
+                        "description": "Mapping of database property names to values for the new page",
+                        "type": "object"
                       }
-                    }
+                    },
+                    "required": ["properties"],
+                    "type": "object"
+                  },
+                  "database_id": {
+                    "format": "uuid",
+                    "type": "string"
                   }
-                }
+                },
+                "required": ["database_id", "body"],
+                "type": "object"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "Created page details",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
                   "properties": {
                     "page_id": {
                       "type": "string"
                     },
                     "properties": {
-                      "type": "object",
-                      "description": "Properties of the newly created page"
+                      "description": "Properties of the newly created page",
+                      "type": "object"
                     }
-                  }
+                  },
+                  "type": "object"
                 }
               }
-            }
+            },
+            "description": "Created page details"
           },
           "400": {
             "description": "Invalid request or structure"
           }
-        }
+        },
+        "summary": "Create a Notion-style page in a database (nested under 'body')",
+        "x-openai-isConsequential": false,
+        "x-openai-requiresUserConfirmation": false
+      }
+    },
+    "/getDB": {
+      "get": {
+        "operationId": "getDB",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "database_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "properties": {
+                      "description": "Database property schema",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Database details"
+          },
+          "400": {
+            "description": "Invalid database_id or structure"
+          }
+        },
+        "summary": "Retrieve a Notion-style database by ID",
+        "x-openai-isConsequential": false,
+        "x-openai-requiresUserConfirmation": false
+      }
+    },
+    "/queryDB": {
+      "post": {
+        "operationId": "queryDB",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "body": {
+                    "properties": {
+                      "filter": {
+                        "description": "Compound filter using and/or logic",
+                        "type": "object"
+                      },
+                      "page_size": {
+                        "default": 100,
+                        "maximum": 100,
+                        "type": "integer"
+                      },
+                      "sorts": {
+                        "items": {
+                          "properties": {
+                            "direction": {
+                              "enum": ["ascending", "descending"],
+                              "type": "string"
+                            },
+                            "property": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "start_cursor": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "database_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  }
+                },
+                "required": ["database_id", "body"],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "next_cursor": {
+                      "type": ["string", "null"]
+                    },
+                    "results": {
+                      "items": {
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Query results"
+          },
+          "400": {
+            "description": "Invalid request or structure"
+          }
+        },
+        "summary": "Query a Notion-style database (nested under 'body')",
+        "x-openai-isConsequential": false,
+        "x-openai-requiresUserConfirmation": false
       }
     }
-  }
+  },
+  "servers": [
+    {
+      "description": "Main API server",
+      "url": "https://qylabn8n.duckdns.org/webhook"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- reorder keys alphabetically within `notion-webhook.json`
- fix invalid `next_cursor` definition

## Testing
- `npm run format` *(fails: package.json missing)*
- `npx prettier -w openapi/notion-webhook.json`
- `npx @redocly/openapi-cli validate openapi/notion-webhook.json`

------
https://chatgpt.com/codex/tasks/task_e_68406f143f30832f8661b66d7fc1ade8