### PR TITLE
Add block management and search endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Custom GPT ──► (OpenAPI Action) ──► n8n Web‑hook ──► Functi
 | `/getDB`      | **GET**  | Fetch database meta by `database_id` query param                                            |
 | `/queryDB`    | **POST** | Complex database query.  **All user params MUST be nested under a top‑level `body` object** |
 | `/createPage` | **POST** | Create a page inside a database. Payload shape identical to Notion’s but wrapped in `body`  |
+| `/appendBlock` | **POST** | Append children to an existing block. Parameters nested under `body` |
+| `/getBlock` | **GET** | Fetch block content by `block_id` query param |
+| `/searchObjects` | **POST** | Search pages and blocks. All user params nested under `body` |
+| `/updateBlock` | **POST** | Update an existing block. All user params nested under `body` |
+| `/uploadFile` | **POST** | Upload a file to a page. All user params nested under `body` |
 
 > **IMPORTANT RULES**
 >

--- a/openapi/notion-webhook.json
+++ b/openapi/notion-webhook.json
@@ -207,6 +207,239 @@
           }
         }
       }
+    },
+    "/appendBlock": {
+      "post": {
+        "summary": "Append child blocks to an existing block (nested under 'body')",
+        "operationId": "appendBlock",
+        "x-openai-isConsequential": false,
+        "x-openai-requiresUserConfirmation": false,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["block_id", "body"],
+                "properties": {
+                  "block_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "body": {
+                    "type": "object",
+                    "required": ["children"],
+                    "properties": {
+                      "children": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Child blocks appended",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or structure"
+          }
+        }
+      }
+    },
+    "/getBlock": {
+      "get": {
+        "summary": "Retrieve a Notion-style block by ID",
+        "operationId": "getBlock",
+        "x-openai-isConsequential": false,
+        "x-openai-requiresUserConfirmation": false,
+        "parameters": [
+          {
+            "name": "block_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Block details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or structure"
+          }
+        }
+      }
+    },
+    "/searchObjects": {
+      "post": {
+        "summary": "Search across pages and blocks (nested under 'body')",
+        "operationId": "searchObjects",
+        "x-openai-isConsequential": false,
+        "x-openai-requiresUserConfirmation": false,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["body"],
+                "properties": {
+                  "body": {
+                    "type": "object",
+                    "properties": {
+                      "filter": {
+                        "type": "object"
+                      },
+                      "query": {
+                        "type": "string"
+                      },
+                      "sort": {
+                        "type": "object"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or structure"
+          }
+        }
+      }
+    },
+    "/updateBlock": {
+      "post": {
+        "summary": "Update a Notion-style block (nested under 'body')",
+        "operationId": "updateBlock",
+        "x-openai-isConsequential": false,
+        "x-openai-requiresUserConfirmation": false,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["block_id", "body"],
+                "properties": {
+                  "block_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "body": {
+                    "type": "object",
+                    "description": "Fields to update on the block"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated block details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or structure"
+          }
+        }
+      }
+    },
+    "/uploadFile": {
+      "post": {
+        "summary": "Upload a file and attach it to a page (nested under 'body')",
+        "operationId": "uploadFile",
+        "x-openai-isConsequential": false,
+        "x-openai-requiresUserConfirmation": false,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["page_id", "body"],
+                "properties": {
+                  "page_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "body": {
+                    "type": "object",
+                    "required": ["name", "url"],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "url": {
+                        "type": "string",
+                        "format": "uri"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "File uploaded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or structure"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add `/appendBlock`, `/getBlock`, `/searchObjects`, `/updateBlock` and `/uploadFile` paths
- document new endpoints in README

## Testing
- `npm run lint:spec` *(fails: Could not read package.json)*
- `npm run lint:md` *(fails: Could not read package.json)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68406f1606d8832f9ea0403c2685a8f0