### PR TITLE
Update updateBlock spec & cursor schema

### DIFF
--- a/openapi/notion-webhook.json
+++ b/openapi/notion-webhook.json
@@ -1,5 +1,8 @@
 {
   "info": {
+    "contact": {
+      "email": "support@example.com"
+    },
     "description": "Modified to support n8n Webhook parsing. All parameters are wrapped in a 'body' object.",
     "title": "Notion Custom API (Body Nested)",
     "version": "1.0.2"
@@ -368,12 +371,16 @@
                     "has_more": {
                       "type": "boolean"
                     },
-                    "next_cursor": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
+                      "next_cursor": {
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
                     "results": {
                       "items": {
                         "type": "object"
@@ -442,22 +449,25 @@
           "content": {
             "application/json": {
               "schema": {
-                "properties": {
-                  "body": {
-                    "properties": {
-                      "archived": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string"
-                      }
+                  "properties": {
+                    "block_id": {
+                      "type": "string"
                     },
-                    "type": "object"
+                    "body": {
+                      "properties": {
+                        "archived": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "enum": [
+                            "text",
+                            "to_do"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    }
                   },
-                  "block_id": {
-                    "type": "string"
-                  }
-                },
                 "required": [
                   "block_id",
                   "body"


### PR DESCRIPTION
## Summary
- add contact info to spec
- allow `next_cursor` to be null via `oneOf`
- enforce text/to_do options in updateBlock `type`

## Testing
- `npm run lint:spec`
- `npx -y @redocly/openapi-cli lint openapi/notion-webhook.json`


------
https://chatgpt.com/codex/tasks/task_e_684114487ea0832f83a93db6817ae593