### PR TITLE
Expand Notion query filter schema

### DIFF
--- a/openapi/notion-webhook.json
+++ b/openapi/notion-webhook.json
@@ -316,6 +316,73 @@
                     "properties": {
                       "filter": {
                         "description": "Compound filter using and/or logic",
+                        "example": {
+                          "or": [
+                            {
+                              "property": "In stock",
+                              "checkbox": {
+                                "equals": true
+                              }
+                            },
+                            {
+                              "property": "Cost of next trip",
+                              "number": {
+                                "greater_than_or_equal_to": 2
+                              }
+                            }
+                          ]
+                        },
+                        "properties": {
+                          "and": {
+                            "items": {
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "checkbox": {
+                            "properties": {
+                              "does_not_equal": {
+                                "type": "boolean"
+                              },
+                              "equals": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "number": {
+                            "properties": {
+                              "does_not_equal": {
+                                "type": "number"
+                              },
+                              "equals": {
+                                "type": "number"
+                              },
+                              "greater_than": {
+                                "type": "number"
+                              },
+                              "greater_than_or_equal_to": {
+                                "type": "number"
+                              },
+                              "less_than": {
+                                "type": "number"
+                              },
+                              "less_than_or_equal_to": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "or": {
+                            "items": {
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "property": {
+                            "type": "string"
+                          }
+                        },
                         "type": "object"
                       },
                       "page_size": {


### PR DESCRIPTION
## Summary
- expand `filter` object in the Notion webhook spec
- add a filtering example for clarity

## Testing
- `npm run lint:spec`

------
https://chatgpt.com/codex/tasks/task_e_6850c8fd69c4832f8d31f965dce34001