### PR TITLE
feat: add file upload endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Custom GPT ──► (OpenAPI Action) ──► n8n Web‑hook ──► Functi
 | ----- | ----- | ------- |
 | `/appendBlockChildren` | **PATCH** | Append blocks to a container block |
 | `/createDatabase` | **POST** | Create a new database under a parent page |
+| `/createFileUpload` | **POST** | Create a file upload |
 | `/createPage` | **POST** | Create a page inside a database. Payload shape identical to Notion’s but wrapped in `body` |
 | `/deleteBlock` | **DELETE** | Move a block to the trash |
 | `/getBlock` | **GET** | Retrieve a single block by `block_id` query param |

--- a/openapi/notion-webhook.json
+++ b/openapi/notion-webhook.json
@@ -117,6 +117,65 @@
         "x-openai-requiresUserConfirmation": false
       }
     },
+    "/createFileUpload": {
+      "post": {
+        "description": "Create a file upload that can be attached to Notion blocks or pages.",
+        "operationId": "createFileUpload",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "body": {
+                    "properties": {
+                      "content_type": {
+                        "type": "string"
+                      },
+                      "external_url": {
+                        "type": "string"
+                      },
+                      "filename": {
+                        "type": "string"
+                      },
+                      "mode": {
+                        "type": "string"
+                      },
+                      "number_of_parts": {
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "mode",
+                      "filename",
+                      "content_type",
+                      "number_of_parts",
+                      "external_url"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "body"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Created file upload details"
+          },
+          "400": {
+            "description": "Invalid request"
+          }
+        },
+        "summary": "Create a file upload",
+        "x-openai-isConsequential": false,
+        "x-openai-requiresUserConfirmation": false
+      }
+    },
     "/createPage": {
       "post": {
         "operationId": "createPage",


### PR DESCRIPTION
## Summary
- add `/createFileUpload` webhook path in OpenAPI spec
- document new endpoint in README

## Testing
- `npm run lint:spec`
- `npm run lint:md` *(fails: multiple markdownlint errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e6aacb510832faa4e8d39114680e4