### PR TITLE
Fix Notion body serialization

### DIFF
--- a/openapi/notion-webhook.json
+++ b/openapi/notion-webhook.json
@@ -75,6 +75,18 @@
                   "body": {
                     "properties": {
                       "properties": {
+                        "additionalProperties": true,
+                        "example": {
+                          "Name": {
+                            "title": [
+                              {
+                                "text": {
+                                  "content": "New DB title"
+                                }
+                              }
+                            ]
+                          }
+                        },
                         "type": "object"
                       },
                       "title": {
@@ -194,7 +206,19 @@
                         "type": "array"
                       },
                       "properties": {
+                        "additionalProperties": true,
                         "description": "Mapping of database property names to values for the new page",
+                        "example": {
+                          "Name": {
+                            "title": [
+                              {
+                                "text": {
+                                  "content": "Task A"
+                                }
+                              }
+                            ]
+                          }
+                        },
                         "type": "object"
                       }
                     },
@@ -680,6 +704,18 @@
                         "type": "boolean"
                       },
                       "properties": {
+                        "additionalProperties": true,
+                        "example": {
+                          "Name": {
+                            "title": [
+                              {
+                                "text": {
+                                  "content": "Updated title"
+                                }
+                              }
+                            ]
+                          }
+                        },
                         "type": "object"
                       }
                     },

--- a/tests/serialization-check.js
+++ b/tests/serialization-check.js
@@ -1,0 +1,35 @@
+const sample = {
+  body: {
+    properties: {
+      Name: {
+        title: [{ text: { content: 'Task "A"\nNext line' } }],
+      },
+      Notes: {
+        rich_text: [
+          { text: { content: 'Special chars: \\ " \' , and emoji 🎉' } },
+        ],
+      },
+      Tags: {
+        multi_select: [
+          { name: 'alpha,beta' },
+          { name: 'γδ' },
+        ],
+      },
+    },
+  },
+  database_id: '12345678-1234-1234-1234-1234567890ab',
+};
+
+function safeSerialize(obj) {
+  return JSON.stringify(obj);
+}
+
+const serialized = safeSerialize(sample);
+const parsed = JSON.parse(serialized);
+
+if (JSON.stringify(parsed) === JSON.stringify(sample)) {
+  console.log('Serialization OK');
+} else {
+  console.error('Mismatch after serialization');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- allow arbitrary property keys in createPage, updatePage and createDatabase
- simplify the example for createPage
- add a serialization check script

## Testing
- `npm run lint:spec`
- `npm run lint:md` *(fails: lots of warnings)*
- `npm test`
- `node tests/serialization-check.js`


------
https://chatgpt.com/codex/tasks/task_e_68897a533b84832fb2d15f554cf126fd