### PR TITLE
fix: convert debug payload to YAML object

### DIFF
--- a/gpts/actions.yaml
+++ b/gpts/actions.yaml
@@ -1,0 +1,44 @@
+---
+actions:
+  - debug_message_payload:
+      request:
+        body:
+          children:
+            - object: block
+              paragraph:
+                rich_text:
+                  - text:
+                      content: |
+                        ## 6 Routine operations
+
+                        | Task              | Command / Notes                                                                                      | Source       |
+                        |-------------------|------------------------------------------------------------------------------------|--------------|
+                        | **Upgrade images** | `docker compose pull && docker compose up -d`                                                      | n8n Docs     |
+                        | **Full workflow backup** | `docker exec n8n n8n export:workflow --all --output /files/all.json`                      | n8n Docs     |
+                        | **Postgres dump** | `docker exec postgres pg_dump -U n8n n8n | gzip > /opt/backups/n8n_$(date +%F).sql.gz`             | n8n Docs     |
+                        | **Monitoring**    | Add an Uptime-Kuma container on the same network.                                                  | GitHub       |
+                        | **Hardening**     | `apt install fail2ban` then enable the sshd jail to block brute-force.                             | HowtoForge   |
+                    type: text
+              type: paragraph
+          properties:
+            기억ID:
+              title:
+                - text:
+                    content: "자주 하는 작업"
+            기억날짜:
+              date:
+                start: "2025-08-01"
+            기억요약:
+              rich_text:
+                - text:
+                    content: "n8n 운영환경에서 자주 수행하는 6가지 작업(업그레이드, 백업, 모니터링, 보안) 정리"
+            기억유형:
+              multi_select:
+                - name: "학습"
+            키워드:
+              rich_text:
+                - text:
+                    content: "n8n routine operations, docker, backup, security"
+        database_id: 2114e835b22080929d97e2396de8fa97
+    operationId: createPage
+openapi: ../openapi/notion-webhook.json


### PR DESCRIPTION
## Summary
- replace `createPage` action's `debug_message_payload` string with structured YAML

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 200}}}' gpts/actions.yaml`
- `npm run lint:spec`
- `npm run lint:md` *(fails: MD013/line-length, MD022/blanks-around-headings, etc.)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c736f1300832fb338de4ba6805667