### PR TITLE
refactor: flatten request payload schemas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ This file gives **OpenAI Codex** the exact rules it must follow when editing or
 ## 3. OpenAPI Contract Rules
 
 1. **Paths must remain as web‑hook routes**—never mirror original Notion REST paths.
-2. Every user‑supplied input **must be nested under a root `body` object** unless the parameter is a simple `query` string.
+2. Every user‑supplied input **must appear directly at the root of the request body** unless the parameter is a simple `query` string.
 3. Preserve existing `operationId` values.
 4. All new endpoints **require**:
 
@@ -62,7 +62,7 @@ Codex, when you execute shell commands, you **must** prepend them with `npm run`
 ## 6. Prohibited Actions
 
 * Do **NOT** rename or delete existing paths.
-* Do **NOT** unwrap `body` into top‑level parameters.
+* Do **NOT** wrap payload fields under a `body` object.
 * Do **NOT** change the `servers[0].url` unless explicitly instructed.
 * Do **NOT** bump `info.version` without updating changelog in PR description.
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Custom GPT ──► (OpenAPI Action) ──► n8n Web‑hook ──► Functi
 | `/appendBlockChildren` | **PATCH** | Append blocks to a container block |
 | `/createDatabase` | **POST** | Create a new database under a parent page |
 | `/createFileUpload` | **POST** | Create a file upload |
-| `/createPage` | **POST** | Create a page inside a database. Payload shape identical to Notion’s but wrapped in `body` |
+| `/createPage` | **POST** | Create a page inside a database |
 | `/deleteBlock` | **DELETE** | Move a block to the trash |
 | `/getBlock` | **GET** | Retrieve a single block by `block_id` query param |
 | `/getBlockChildren` | **GET** | Fetch children blocks for a container block |
 | `/getDB` | **GET** | Fetch database meta by `database_id` query param |
 | `/getPage` | **GET** | Retrieve page details by `page_id` query param |
-| `/queryDB` | **POST** | Complex database query.  **All user params MUST be nested under a top‑level `body` object** |
+| `/queryDB` | **POST** | Complex database query |
 | `/search` | **POST** | Search across pages and databases |
 | `/updateBlock` | **PATCH** | Update block content or archived state |
 | `/updateDatabase` | **PATCH** | Update database title or properties |
@@ -37,8 +37,8 @@ Custom GPT ──► (OpenAPI Action) ──► n8n Web‑hook ──► Functi
 > **IMPORTANT RULES**
 >
 > 1. *Do not* change existing paths. They are the contract expected by n8n.
-> 2. Parameters must stay wrapped under a single root object (`body`) so that the n8n Function node can consume them without extra parsing.
-> 3. New functionality **must follow the same wrapping convention** and live under the `/` root, *not* the original Notion URL schema (e.g. **never** `/databases/{id}/query`).
+> 2. Parameters are provided as a single JSON object with all fields at the top level so the n8n Function node can consume them without extra parsing.
+> 3. New functionality **must follow the same flattened structure** and live under the `/` root, *not* the original Notion URL schema (e.g. **never** `/databases/{id}/query`).
 
 ### 🛠 Local Development
 

--- a/openapi/notion-webhook.json
+++ b/openapi/notion-webhook.json
@@ -3,8 +3,8 @@
     "contact": {
       "email": "support@example.com"
     },
-    "description": "Modified to support n8n Webhook parsing. All parameters are wrapped in a 'body' object.",
-    "title": "Notion Custom API (Body Nested)",
+    "description": "Modified to support n8n Webhook parsing. All parameters are provided at the top level.",
+    "title": "Notion Custom API",
     "version": "1.0.2"
   },
   "openapi": "3.1.0",
@@ -18,31 +18,23 @@
             "application/json": {
               "schema": {
                 "properties": {
-                  "body": {
-                    "properties": {
-                      "after": {
-                        "description": "ID of an existing child to insert after",
-                        "type": "string"
-                      },
-                      "children": {
-                        "items": {
-                          "type": "object"
-                        },
-                        "type": "array"
-                      }
-                    },
-                    "required": [
-                      "children"
-                    ],
-                    "type": "object"
+                  "after": {
+                    "description": "ID of an existing child to insert after",
+                    "type": "string"
                   },
                   "block_id": {
                     "type": "string"
+                  },
+                  "children": {
+                    "items": {
+                      "type": "object"
+                    },
+                    "type": "array"
                   }
                 },
                 "required": [
                   "block_id",
-                  "body"
+                  "children"
                 ],
                 "type": "object"
               }
@@ -72,31 +64,23 @@
             "application/json": {
               "schema": {
                 "properties": {
-                  "body": {
-                    "properties": {
-                      "properties": {
-                        "type": "object"
-                      },
-                      "title": {
-                        "items": {
-                          "type": "object"
-                        },
-                        "type": "array"
-                      }
-                    },
-                    "required": [
-                      "title",
-                      "properties"
-                    ],
-                    "type": "object"
-                  },
                   "parent_page_id": {
                     "type": "string"
+                  },
+                  "properties": {
+                    "type": "object"
+                  },
+                  "title": {
+                    "items": {
+                      "type": "object"
+                    },
+                    "type": "array"
                   }
                 },
                 "required": [
                   "parent_page_id",
-                  "body"
+                  "properties",
+                  "title"
                 ],
                 "type": "object"
               }
@@ -125,33 +109,25 @@
             "application/json": {
               "schema": {
                 "properties": {
-                  "body": {
-                    "properties": {
-                      "children": {
-                        "description": "Optional array of block children to include under the page",
-                        "items": {
-                          "type": "object"
-                        },
-                        "type": "array"
-                      },
-                      "properties": {
-                        "description": "Mapping of database property names to values for the new page",
-                        "type": "object"
-                      }
+                  "children": {
+                    "description": "Optional array of block children to include under the page",
+                    "items": {
+                      "type": "object"
                     },
-                    "required": [
-                      "properties"
-                    ],
-                    "type": "object"
+                    "type": "array"
                   },
                   "database_id": {
                     "format": "uuid",
                     "type": "string"
+                  },
+                  "properties": {
+                    "description": "Mapping of database property names to values for the new page",
+                    "type": "object"
                   }
                 },
                 "required": [
                   "database_id",
-                  "body"
+                  "properties"
                 ],
                 "type": "object"
               }
@@ -167,7 +143,7 @@
             "description": "Invalid request"
           }
         },
-        "summary": "Create a Notion-style page in a database (nested under 'body')",
+        "summary": "Create a Notion-style page in a database",
         "x-openai-isConsequential": false,
         "x-openai-requiresUserConfirmation": false
       }
@@ -312,116 +288,110 @@
             "application/json": {
               "schema": {
                 "properties": {
-                  "body": {
-                    "properties": {
-                      "filter": {
-                        "description": "Compound filter using and/or logic",
-                        "example": {
-                          "or": [
-                            {
-                              "property": "In stock",
-                              "checkbox": {
-                                "equals": true
-                              }
-                            },
-                            {
-                              "property": "Cost of next trip",
-                              "number": {
-                                "greater_than_or_equal_to": 2
-                              }
-                            }
-                          ]
-                        },
-                        "properties": {
-                          "and": {
-                            "items": {
-                              "type": "object"
-                            },
-                            "type": "array"
-                          },
+                  "database_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "filter": {
+                    "description": "Compound filter using and/or logic",
+                    "example": {
+                      "or": [
+                        {
+                          "property": "In stock",
                           "checkbox": {
-                            "properties": {
-                              "does_not_equal": {
-                                "type": "boolean"
-                              },
-                              "equals": {
-                                "type": "boolean"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "number": {
-                            "properties": {
-                              "does_not_equal": {
-                                "type": "number"
-                              },
-                              "equals": {
-                                "type": "number"
-                              },
-                              "greater_than": {
-                                "type": "number"
-                              },
-                              "greater_than_or_equal_to": {
-                                "type": "number"
-                              },
-                              "less_than": {
-                                "type": "number"
-                              },
-                              "less_than_or_equal_to": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "or": {
-                            "items": {
-                              "type": "object"
-                            },
-                            "type": "array"
-                          },
-                          "property": {
-                            "type": "string"
+                            "equals": true
                           }
                         },
-                        "type": "object"
-                      },
-                      "page_size": {
-                        "default": 100,
-                        "maximum": 100,
-                        "type": "integer"
-                      },
-                      "sorts": {
+                        {
+                          "property": "Cost of next trip",
+                          "number": {
+                            "greater_than_or_equal_to": 2
+                          }
+                        }
+                      ]
+                    },
+                    "properties": {
+                      "and": {
                         "items": {
-                          "properties": {
-                            "direction": {
-                              "enum": [
-                                "ascending",
-                                "descending"
-                              ],
-                              "type": "string"
-                            },
-                            "property": {
-                              "type": "string"
-                            }
-                          },
                           "type": "object"
                         },
                         "type": "array"
                       },
-                      "start_cursor": {
+                      "checkbox": {
+                        "properties": {
+                          "does_not_equal": {
+                            "type": "boolean"
+                          },
+                          "equals": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "number": {
+                        "properties": {
+                          "does_not_equal": {
+                            "type": "number"
+                          },
+                          "equals": {
+                            "type": "number"
+                          },
+                          "greater_than": {
+                            "type": "number"
+                          },
+                          "greater_than_or_equal_to": {
+                            "type": "number"
+                          },
+                          "less_than": {
+                            "type": "number"
+                          },
+                          "less_than_or_equal_to": {
+                            "type": "number"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "or": {
+                        "items": {
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "property": {
                         "type": "string"
                       }
                     },
                     "type": "object"
                   },
-                  "database_id": {
-                    "format": "uuid",
+                  "page_size": {
+                    "default": 100,
+                    "maximum": 100,
+                    "type": "integer"
+                  },
+                  "sorts": {
+                    "items": {
+                      "properties": {
+                        "direction": {
+                          "enum": [
+                            "ascending",
+                            "descending"
+                          ],
+                          "type": "string"
+                        },
+                        "property": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "start_cursor": {
                     "type": "string"
                   }
                 },
                 "required": [
-                  "database_id",
-                  "body"
+                  "database_id"
                 ],
                 "type": "object"
               }
@@ -465,7 +435,7 @@
             "description": "Invalid request or structure"
           }
         },
-        "summary": "Query a Notion-style database (nested under 'body')",
+        "summary": "Query a Notion-style database",
         "x-openai-isConsequential": false,
         "x-openai-requiresUserConfirmation": false
       }
@@ -478,17 +448,12 @@
             "application/json": {
               "schema": {
                 "properties": {
-                  "body": {
-                    "properties": {
-                      "query": {
-                        "type": "string"
-                      }
-                    },
-                    "type": "object"
+                  "query": {
+                    "type": "string"
                   }
                 },
                 "required": [
-                  "body"
+                  "query"
                 ],
                 "type": "object"
               }
@@ -516,28 +481,22 @@
           "content": {
             "application/json": {
               "schema": {
-                  "properties": {
-                    "block_id": {
-                      "type": "string"
-                    },
-                    "body": {
-                      "properties": {
-                        "archived": {
-                          "type": "boolean"
-                        },
-                        "type": {
-                          "enum": [
-                            "text",
-                            "to_do"
-                          ]
-                        }
-                      },
-                      "type": "object"
-                    }
+                "properties": {
+                  "archived": {
+                    "type": "boolean"
                   },
+                  "block_id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "text",
+                      "to_do"
+                    ]
+                  }
+                },
                 "required": [
-                  "block_id",
-                  "body"
+                  "block_id"
                 ],
                 "type": "object"
               }
@@ -566,27 +525,21 @@
             "application/json": {
               "schema": {
                 "properties": {
-                  "body": {
-                    "properties": {
-                      "properties": {
-                        "type": "object"
-                      },
-                      "title": {
-                        "items": {
-                          "type": "object"
-                        },
-                        "type": "array"
-                      }
-                    },
-                    "type": "object"
-                  },
                   "database_id": {
                     "type": "string"
+                  },
+                  "properties": {
+                    "type": "object"
+                  },
+                  "title": {
+                    "items": {
+                      "type": "object"
+                    },
+                    "type": "array"
                   }
                 },
                 "required": [
-                  "database_id",
-                  "body"
+                  "database_id"
                 ],
                 "type": "object"
               }
@@ -615,24 +568,18 @@
             "application/json": {
               "schema": {
                 "properties": {
-                  "body": {
-                    "properties": {
-                      "archived": {
-                        "type": "boolean"
-                      },
-                      "properties": {
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
+                  "archived": {
+                    "type": "boolean"
                   },
                   "page_id": {
                     "type": "string"
+                  },
+                  "properties": {
+                    "type": "object"
                   }
                 },
                 "required": [
-                  "page_id",
-                  "body"
+                  "page_id"
                 ],
                 "type": "object"
               }

--- a/tests/serialization-check.js
+++ b/tests/serialization-check.js
@@ -1,23 +1,21 @@
 const sample = {
-  body: {
-    properties: {
-      Name: {
-        title: [{ text: { content: 'Task "A"\nNext line' } }],
-      },
-      Notes: {
-        rich_text: [
-          { text: { content: 'Special chars: \\ " \' , and emoji 🎉' } },
-        ],
-      },
-      Tags: {
-        multi_select: [
-          { name: 'alpha,beta' },
-          { name: 'γδ' },
-        ],
-      },
+  database_id: '12345678-1234-1234-1234-1234567890ab',
+  properties: {
+    Name: {
+      title: [{ text: { content: 'Task "A"\nNext line' } }],
+    },
+    Notes: {
+      rich_text: [
+        { text: { content: 'Special chars: \\ " \' , and emoji 🎉' } },
+      ],
+    },
+    Tags: {
+      multi_select: [
+        { name: 'alpha,beta' },
+        { name: 'γδ' },
+      ],
     },
   },
-  database_id: '12345678-1234-1234-1234-1234567890ab',
 };
 
 function safeSerialize(obj) {


### PR DESCRIPTION
## Summary
- flatten webhook request JSON by removing `body` wrapper
- update docs and guidelines for top-level payload fields
- adjust tests for new JSON structure

## Testing
- `npm run lint:spec`
- `npm run lint:md` *(fails: numerous markdownlint errors in notion-api docs)*
- `npm test`
- `node tests/serialization-check.js`


------
https://chatgpt.com/codex/tasks/task_e_6896102ffc9c832fa49488d65f8454b9